### PR TITLE
  broken links to download original paris/oxford dataset

### DIFF
--- a/utils/download_test.m
+++ b/utils/download_test.m
@@ -27,16 +27,16 @@ function download_test(data_dir)
         dataset = datasets{di};
         switch dataset
             case 'oxford5k'
-                src_dir = fullfile('http://www.robots.ox.ac.uk/~vgg/data/oxbuildings');
+                src_dir = fullfile('https://www.robots.ox.ac.uk/~vgg/data/oxbuildings');
                 dl_files = {'oxbuild_images-v1.tgz'};
             case 'paris6k'
-                src_dir = fullfile('http://www.robots.ox.ac.uk/~vgg/data/parisbuildings');
+                src_dir = fullfile('https://www.robots.ox.ac.uk/~vgg/data/parisbuildings');
                 dl_files = {'paris_1-v1.tgz', 'paris_2-v1.tgz'};
             case 'roxford5k'
-                src_dir = fullfile('http://www.robots.ox.ac.uk/~vgg/data/oxbuildings');
+                src_dir = fullfile('https://www.robots.ox.ac.uk/~vgg/data/oxbuildings');
                 dl_files = {'oxbuild_images-v1.tgz'};
             case 'rparis6k'
-                src_dir = fullfile('http://www.robots.ox.ac.uk/~vgg/data/parisbuildings');
+                src_dir = fullfile('https://www.robots.ox.ac.uk/~vgg/data/parisbuildings');
                 dl_files = {'paris_1-v1.tgz', 'paris_2-v1.tgz'};
             otherwise
                 error ('Unkown dataset %s\n', dataset);

--- a/utils/download_test.m
+++ b/utils/download_test.m
@@ -28,16 +28,16 @@ function download_test(data_dir)
         switch dataset
             case 'oxford5k'
                 src_dir = fullfile('http://www.robots.ox.ac.uk/~vgg/data/oxbuildings');
-                dl_files = {'oxbuild_images.tgz'};
+                dl_files = {'oxbuild_images-v1.tgz'};
             case 'paris6k'
                 src_dir = fullfile('http://www.robots.ox.ac.uk/~vgg/data/parisbuildings');
-                dl_files = {'paris_1.tgz', 'paris_2.tgz'};
+                dl_files = {'paris_1-v1.tgz', 'paris_2-v1.tgz'};
             case 'roxford5k'
                 src_dir = fullfile('http://www.robots.ox.ac.uk/~vgg/data/oxbuildings');
-                dl_files = {'oxbuild_images.tgz'};
+                dl_files = {'oxbuild_images-v1.tgz'};
             case 'rparis6k'
                 src_dir = fullfile('http://www.robots.ox.ac.uk/~vgg/data/parisbuildings');
-                dl_files = {'paris_1.tgz', 'paris_2.tgz'};
+                dl_files = {'paris_1-v1.tgz', 'paris_2-v1.tgz'};
             otherwise
                 error ('Unkown dataset %s\n', dataset);
         end


### PR DESCRIPTION
VGG has released new versions of the Paris and Oxford datasets with the faces blurred. The original datasets are no longer available. This PR fixes the download.